### PR TITLE
Refactor: simplify child paint offset calculation for scroll hijack sliver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 * Corrected scroll offset is used for `hasVisualOverflow` calculation, to avoid clipping when it is not necessary.
+* Simplify child paintOffset calculation of ScrollHijackSliver for case of reverse scrolling.
 
 ## 0.1.3
 ### Added

--- a/lib/src/base/scroll_hijack_sliver.dart
+++ b/lib/src/base/scroll_hijack_sliver.dart
@@ -397,22 +397,8 @@ class _HijackRenderSliver extends RenderSliver
     );
 
     final paintOffset = switch (actualGrowthDirection) {
-      AxisDirection.up => _isConsumingSpace
-          ? Offset.zero
-          : Offset(
-              0.0,
-              geometry.paintExtent +
-                  constraints.scrollOffset -
-                  geometry.scrollExtent,
-            ),
-      AxisDirection.left => _isConsumingSpace
-          ? Offset.zero
-          : Offset(
-              geometry.paintExtent +
-                  constraints.scrollOffset -
-                  geometry.scrollExtent,
-              0.0,
-            ),
+      AxisDirection.up => Offset.zero,
+      AxisDirection.left => Offset.zero,
       AxisDirection.right =>
         _isConsumingSpace ? Offset.zero : Offset(-_correctedScrollOffset, 0.0),
       AxisDirection.down =>


### PR DESCRIPTION
In case of reverse scrolling, there were unnecessary calculations that always resulted in 0. Which totally makes sense - there should not be an offset, it is always in 0 of local coordinates for reverse scrolling.